### PR TITLE
[Checkout] - Set Default Country Id For Shipping Address

### DIFF
--- a/Model/DefaultConfigProvider.php
+++ b/Model/DefaultConfigProvider.php
@@ -11,7 +11,10 @@ use Magento\Customer\Model\Address\CustomerAddressDataProvider;
 use Magento\Customer\Model\Context as CustomerContext;
 use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Directory\Model\Country\Postcode\ConfigInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Http\Context as HttpContext;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Tax\Model\Config as TaxConfig;
 
 class DefaultConfigProvider implements ConfigProviderInterface
 {
@@ -46,6 +49,11 @@ class DefaultConfigProvider implements ConfigProviderInterface
     private $postcodeConfig;
 
     /**
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
      * Class constructor
      *
      * @param \Magento\Checkout\Model\Session $checkoutSession
@@ -61,7 +69,8 @@ class DefaultConfigProvider implements ConfigProviderInterface
         CustomerRepositoryInterface $customerRepository,
         CustomerSession $customerSession,
         CustomerAddressDataProvider $customerAddressData,
-        ConfigInterface $postcodeConfig
+        ConfigInterface $postcodeConfig,
+        ScopeConfigInterface $scopeConfig
     ) {
         $this->checkoutSession = $checkoutSession;
         $this->httpContext = $httpContext;
@@ -69,6 +78,7 @@ class DefaultConfigProvider implements ConfigProviderInterface
         $this->customerSession = $customerSession;
         $this->customerAddressData = $customerAddressData;
         $this->postcodeConfig = $postcodeConfig;
+        $this->scopeConfig = $scopeConfig;
     }
 
     /**
@@ -82,7 +92,8 @@ class DefaultConfigProvider implements ConfigProviderInterface
             'storeCode' => $this->getStoreCode(),
             'isCustomerLoggedIn' => $this->isCustomerLoggedIn(),
             'customerData' => $this->getCustomerData(),
-            'postCodes' => $this->postcodeConfig->getPostCodes()
+            'postCodes' => $this->postcodeConfig->getPostCodes(),
+            'defaultCountryId' => $this->getDefaultCountryId()
         ];
     }
 
@@ -132,5 +143,18 @@ class DefaultConfigProvider implements ConfigProviderInterface
     private function getCustomer()
     {
         return $this->customerRepository->getById($this->customerSession->getCustomerId());
+    }
+
+    /**
+     * Retrieve default country id
+     *
+     * @return string
+     */
+    private function getDefaultCountryId()
+    {
+        return $this->scopeConfig->getValue(
+            TaxConfig::CONFIG_XML_PATH_DEFAULT_COUNTRY,
+            ScopeInterface::SCOPE_STORE
+        );
     }
 }

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -12,6 +12,7 @@
             <module name="Magento_Quote"/>
             <module name="Magento_CatalogInventory"/>
             <module name="Magento_Checkout"/>
+            <module name="Magento_Tax"/>
         </sequence>
     </module>
 </config>

--- a/view/frontend/web/js/checkout-data.js
+++ b/view/frontend/web/js/checkout-data.js
@@ -15,7 +15,8 @@ define([
     initData = function () {
         return {
             'newCustomerShippingAddress': null,
-            'selectedShippingAddress': null
+            'selectedShippingAddress': null,
+            'shippingAddressFromData': null
         }
     },
 
@@ -95,6 +96,29 @@ define([
             var checkoutData = getData();
 
             return checkoutData.selectedShippingAddress;
+        },
+
+        /**
+         * Set shipping address to the customer data storage
+         *
+         * @param {Object} data
+         */
+        setShippingAddressFromData: function (data) {
+            var checkoutData = getData();
+
+            checkoutData.shippingAddressFromData = data;
+            saveData(checkoutData);
+        },
+
+        /**
+         * Get shipping address from the customer data storage
+         *
+         * @return {*}
+         */
+        getShippingAddressFromData: function () {
+            var checkoutData = getData();
+
+            return checkoutData.shippingAddressFromData;
         }
     }
 });

--- a/view/frontend/web/js/model/checkout-data-resolver.js
+++ b/view/frontend/web/js/model/checkout-data-resolver.js
@@ -7,6 +7,7 @@ define([
     'Barranco_Checkout/js/action/create-shipping-address',
     'Barranco_Checkout/js/action/select-shipping-address',
     'Barranco_Checkout/js/checkout-data',
+    'Barranco_Checkout/js/model/address-converter',
     'Magento_Checkout/js/model/quote',
     'Magento_Customer/js/model/address-list'
 ], function(
@@ -14,6 +15,7 @@ define([
     createShippingAddressAction,
     selectShippingAddressAction,
     checkoutData,
+    addressConverter,
     quote,
     addressList
 ) {
@@ -38,7 +40,15 @@ define([
          * Apply address to quote
          */
         applyShippingAddress: function () {
-            var shippingAddress;
+            var address,
+                shippingAddress;
+
+            if (addressList.length === 0) {
+                address = addressConverter.formAddressDataToQuoteAddress(
+                    checkoutData.getShippingAddressFromData()
+                );
+                selectShippingAddressAction(address);
+            }
 
             shippingAddress = quote.shippingAddress();
 

--- a/view/frontend/web/js/model/new-customer-address.js
+++ b/view/frontend/web/js/model/new-customer-address.js
@@ -5,6 +5,8 @@ define([
 
     return function (addressData) {
 
+        var countryId = addressData['country_id'] || window.checkoutConfig.defaultCountryId;
+
         return {
             firstname: addressData.firstname,
             lastname: addressData.lastname,
@@ -14,7 +16,7 @@ define([
             regionCode: addressData.region['region_code'],
             region: addressData.region.region,
             postcode: addressData.postcode,
-            countryId: addressData['country_id'],
+            countryId: countryId,
             telephone: addressData.telephone,
 
             /**


### PR DESCRIPTION
Set the default country ID for the shipping address in order to fix an issue while shipping address validation.

- This code sets the `defaultCountryId` key to the checkout config
- This code applies a validation if the customer is not logged in and the address list is empty